### PR TITLE
Solution for incorrect CSS importing + final touchups

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,4 @@
 .App {
+  font-family: 'Poppins';
   text-align: center;
 }

--- a/src/assets/Nav.css
+++ b/src/assets/Nav.css
@@ -17,6 +17,7 @@
   font-weight: 700; 
   margin-left: 30px;
   margin-right: 30px;
+  margin-top: 1rem;
 }
 
 .nav-links a {

--- a/src/assets/OfficerCard.css
+++ b/src/assets/OfficerCard.css
@@ -1,6 +1,5 @@
-.card {
+.officer-card {
     padding: 15px;
-    
 }
 
 #officer-pic {
@@ -13,6 +12,7 @@
 #name, #position, #email {
     text-align: left;
     color: #023E8A;
+    
 }
 
 #position {
@@ -22,5 +22,6 @@
 
 #email {
     opacity: 0.8;
-    margin-top: 25px;
+    /* margin-top: 25px; */
+    margin-top: 5px;
 }

--- a/src/assets/ProjectCard.css
+++ b/src/assets/ProjectCard.css
@@ -1,5 +1,5 @@
 
-.card {
+.project-card {
   background: #fff;
   width: 22rem;
   border-radius: 0.4rem;
@@ -10,44 +10,44 @@
   color: #023E8A;
 }
 
-.card:hover {
+.project-card:hover {
   transform: scale(1.03);
   box-shadow: 0 13px 40px -5px hsla(240, 30.1%, 28%, 0.12), 0 8px 32px -8px hsla(0, 0%, 0%, 0.14), 0 -6px 32px -6px hsla(0, 0%, 0%, 0.02);
 }
 
-.card img {
+.project-card img {
   width: 100%;
   object-fit: cover;
 }
 
-.card-body {
+.project-card-body {
   padding: 2rem;
   text-align: left;
 }
 
-.card h2 {
+.project-card h2 {
   color: #023E8A;
-  margin-top: -0.2em;
   line-height: 1.2;
   font-size: 30px;
+  margin-top: -0.rem;
   font-weight: 500;
   transition: all ease-in 100ms;
 }
 
-.card h3 {
+.project-card h3 {
   font-weight: 500;
   font-size: 1.2rem;
-  margin-top: -1rem;
+  margin-top: -0.1rem;
   /* font-size: 18px; */
 }
 
-.card p {
+.project-card p {
   color: #023E8A;
   font-size: 1.0rem;
 }
 
 /* Unused right now */
-/* .card h5 {
+/* .project-card h5 {
   color:#023E8A;
   font-weight: 650;
   font-size: 0.7em;

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -8,7 +8,7 @@ export default function Nav() {
     return (
         <div>
             <nav className = "nav-bar">
-                <img className="logo" src= {imager} alt="temp-logo" /> 
+                <li style= {{ 'list-style' : 'none' }}><Link to ="/WhatWeDo"><img className="logo" src= {imager} alt="temp-logo" /></Link></li> 
                 <ul className="nav-links">
                     <li><Link to ="/WhatWeDo">What We Do</Link></li>
                     <li><Link to ="/Projects">Project</Link></li>

--- a/src/components/OfficerCard.js
+++ b/src/components/OfficerCard.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import '../assets/OfficerCard.css';
 import { Card } from 'react-bootstrap';
-import { Image } from 'react-bootstrap';
 import 'bootstrap/dist/css/bootstrap.min.css';
 
 function OfficerCard(props) {
@@ -16,11 +15,13 @@ function OfficerCard(props) {
      */
     return (
         <>
-            <div className='card' style={ { borderBottom: 'none' } }>
-                <Card style={{ width: '15rem', border: 'none' }}>
+            <div className='officer-card' style={ { borderBottom: 'none' } }>
+                <Card style={{ width: '13rem', border: 'none' }}>
+                {/* <Card style={{ border: 'none' }}> */}
                     <Card.Link href={props.link}>
                         {/* Need to figure out a way to overlay the linkedin logo on the image */}
-                        <Card.Img as={Image} id='officer-pic' variant="top" fluid={true} src={props.url} alt={props.alt} rounded/>
+                        {/* <Card.Img as={Image} id='officer-pic' variant="top" fluid={true} src={props.url} alt={props.alt} rounded/> */}
+                        <Card.Img id='officer-pic' variant='top' src={props.url} alt={props.alt} />
                     </Card.Link>
                     <Card.Body>
                         <Card.Title id='name'>{props.name}</Card.Title>

--- a/src/components/Officers.js
+++ b/src/components/Officers.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import '../assets/Officers.css';
-import Card from './OfficerCard';
+import OfficerCard from './OfficerCard';
 import srirag_photo from '../images/srirag.jpg';
 
 // export default function Officers() {
@@ -15,8 +15,7 @@ const Officers = () => {
     return (
         <div>
             <h3>Part - 1</h3>
-            <Card link='www.example.com' url= {srirag_photo} name="Srirag Vuppala" title="Community Officer" email="srirag@gmail.com" alt="Srirag"></Card>
-            {/* <img className="logo" src= {srirag_photo} alt="temp-logo" />  */}
+            <OfficerCard link='www.example.com' url= {srirag_photo} name="Srirag Vuppala" title="Community Officer" email="srirag@gmail.com" alt="Photo of Srirag" />
         </div>
     )
 }
@@ -33,8 +32,6 @@ const final = () => {
         <>
         <Officers />
         <Bleh />
-        <Card />
-
         </>
     )
     

--- a/src/components/ProjectCard.js
+++ b/src/components/ProjectCard.js
@@ -10,9 +10,9 @@ const ProjectCard = ({title, techStack, url, description}) => {
    *  description: A brief description of the project
    */
   return (
-    <div className="card">
+    <div className="project-card">
       <img src={url} alt="project"/>
-      <div className="card-body">
+      <div className="project-card-body">
         <h2>{title}</h2>
         <h3>{techStack}</h3>
         <p>{description}</p>

--- a/src/components/Projects.js
+++ b/src/components/Projects.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Card from './ProjectCard.js';
+import ProjectCard from './ProjectCard.js';
 import '../assets/Projects.css';
 import default_photo from '../images/project-card-default.png';
 
@@ -7,7 +7,7 @@ export default function Projects() {
     return (
         <div>
             <h3>Projects</h3>        
-            <Card title="Vera" techStack="MongoDB, Express.js, React and Node.js" description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ultrices ipsum, varius congue enim, neque. Tincidunt nisl sit quisque nibh consequat tempor, tortor ultricies." url={default_photo} />
+            <ProjectCard title="Vera" techStack="MongoDB, Express.js, React and Node.js" description="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ultrices ipsum, varius congue enim, neque. Tincidunt nisl sit quisque nibh consequat tempor, tortor ultricies." url={default_photo} />
         </div>
     )
     


### PR DESCRIPTION
**TL;DR** make sure your selectors are unique in the css files! thanks :)

Problem
---
When merging in all the branches I found an issue where each CSS stylesheet for the respective component wasn't localized. (It basically didn't **only** pull from the stylesheet linked and also pulled from other stylesheets in the repo, thus when there was a selector in two stylesheets with the same name the output would look wrong.)

Solution
---
 So I did some reading and found out that this was caused due to a mixture of how react works alongwith 'create-react-app' which this project initially used to start development.
 The downside from the create-react-app/react came from its inception as a SPA(single page application) and did not have a localized protocol of bundling the css files. 
Potential solutions online were replacing the protocol that bundles css files(within webpack) to the CSS-modules which would still require a refactoring of the codebase, this seemed like too much work  (and above my skill-level :/) so the next best thing which I ended up implementing was essentially making sure we name the CSS selectors uniquely like this:

`.[component we are building for]-card {`
`    padding: 15px;`
`    [rest of css stuff]`
`}` 

instead of 
`.card {`
`    padding: 15px;`
`    [rest of css stuff]`
`}`

  