### PR TITLE
Whatwedo additional section

### DIFF
--- a/src/assets/SharedAssets/Styles.css
+++ b/src/assets/SharedAssets/Styles.css
@@ -10,6 +10,8 @@
     --light-gray: #F5F5F5;
     --dark-gray: #9d9d9d;
 
+    --white: #ffffff;
+
     --light-green: #DCECE3;
     --dark-green: #44746C;
 

--- a/src/assets/WhatWeDo/BlueNewsletterSubBox.css
+++ b/src/assets/WhatWeDo/BlueNewsletterSubBox.css
@@ -1,8 +1,8 @@
 @import "../SharedAssets/Styles.css";
 
 .blue-newsletter {
-  background-color: white; 
-  /* background: var(--light-gray); */
+  /*background-color: white;*/ 
+  background: var(--light-gray);
   background-image: url('../../images/background-shapes-desktop.svg');
   height: 380px;
 }

--- a/src/assets/WhatWeDo/WhiteWaveBlock.css
+++ b/src/assets/WhatWeDo/WhiteWaveBlock.css
@@ -118,7 +118,7 @@
     .whitewaveblock {
         padding-top: 2.5rem;
         display: flex;
-        flex-direction: column-reverse;
+        don't need `flex-direction: column-reverse` at this width
     }
 
 }

--- a/src/assets/WhatWeDo/WhiteWaveBlock.css
+++ b/src/assets/WhatWeDo/WhiteWaveBlock.css
@@ -79,7 +79,7 @@
         padding-left: 10%;
         padding-right: 10%;
         display: flex;
-        flex-direction: column-reverse;
+       don't need `flex-direction: column-reverse` at this width
     }
 
 }

--- a/src/assets/WhatWeDo/WhiteWaveBlock.css
+++ b/src/assets/WhatWeDo/WhiteWaveBlock.css
@@ -90,7 +90,7 @@
         padding-left: 8%;
         padding-right: 8%;
         display: flex;
-        flex-direction: column-reverse;
+        don't need `flex-direction: column-reverse` at this width
     }
 
     .whitewaveblock-cta {

--- a/src/assets/WhatWeDo/WhiteWaveBlock.css
+++ b/src/assets/WhatWeDo/WhiteWaveBlock.css
@@ -131,6 +131,7 @@
         display: flex;
         flex-wrap: wrap;
         justify-content: center;
+        align-items: center;
         margin-left: 0;
         margin-right: 0;
         display: flex;

--- a/src/assets/WhatWeDo/WhiteWaveBlock.css
+++ b/src/assets/WhatWeDo/WhiteWaveBlock.css
@@ -133,14 +133,6 @@
         margin-right: 0;
         display: flex;
         flex-direction: column-reverse;
-        /*
-        position: relative;
-        display: flex;
-        margin-top: 0px;
-        z-index: -1;
-        background-color: #CAF0F8;
-        padding: 20px;
-        */
     }
 
     .break {
@@ -171,7 +163,6 @@
     .whitewaveblock {
         height: 490px;
         display: flex;
-        flex-direction: column-reverse;
     }
 
     .whitewaveblock-wave {
@@ -185,7 +176,6 @@
     .whitewaveblock {
         height: 450px;
         display: flex;
-        flex-direction: column-reverse;
     }
 
 }

--- a/src/assets/WhatWeDo/WhiteWaveBlock.css
+++ b/src/assets/WhatWeDo/WhiteWaveBlock.css
@@ -1,0 +1,180 @@
+@import "../SharedAssets/Styles.css";
+
+.whitewaveblock-container {
+    position: relative;
+    z-index: -10;
+    margin-bottom: 50px;
+}
+
+.whitewaveblock .whitewaveblock-wave {
+    width: 100%;
+    height: 100%;
+}
+
+.whitewaveblock {
+    position: relative;
+    display: flex;
+    margin-top: 0px;
+    z-index: -1;
+    background-color: var(--white);
+    padding-left: 20%;
+    padding-right: 20%;
+    padding-top: 4.5rem;
+}
+
+.whitewaveblock img {
+    width: 80%;
+    max-width: 520px;
+    min-width: 450px;
+}
+
+.whitewaveblock-img {
+    padding-left: 0.2rem;
+    width: 60%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.whitewaveblock-cta {
+    width: 50%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.whitewaveblock-wave {
+    position: relative;
+    margin-top: -10em;
+    z-index: -10;
+}
+
+.break {
+    display: none;
+}
+
+@media screen and (max-width: 1700px) {
+
+    .whitewaveblock {
+        padding-left: 18%;
+        padding-right: 18%;
+    }
+
+    .whitewaveblock-cta {
+        transform: scale(0.9);
+    }
+
+    .whitewaveblock-wave {
+        position: relative;
+        margin-top: -6em;
+        z-index: -10;
+    }
+
+}
+
+@media screen and (max-width: 1450px) {
+
+    .whitewaveblock {
+        padding-left: 10%;
+        padding-right: 10%;
+    }
+
+}
+
+@media screen and (max-width: 1300px) {
+
+    .whitewaveblock {
+        padding-left: 8%;
+        padding-right: 8%;
+    }
+
+    .whitewaveblock-cta {
+        transform: scale(0.8);
+    }
+
+    .whitewaveblock-img {
+        padding-left: 1rem;
+    }
+
+    .whitewaveblock img {
+        width: 80%;
+        min-width: 400px;
+    }
+
+}
+
+@media screen and (max-width: 1100px) {
+/*
+    .whitewaveblock-wave {
+        margin-top: -10em;
+    }
+*/
+
+    .whitewaveblock {
+        padding-top: 2.5rem;
+    }
+
+}
+
+/* 860 */
+
+@media screen and (max-width: 860px) {
+
+    .whitewaveblock {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        margin-left: 0;
+        margin-right: 0;
+        /*
+        position: relative;
+        display: flex;
+        margin-top: 0px;
+        z-index: -1;
+        background-color: #CAF0F8;
+        padding: 20px;
+        */
+    }
+
+    .break {
+        display: block;
+        flex-basis: 100%;
+        height: 0;
+    }
+
+    .whitewaveblock-cta {
+        width: 100%;
+        padding: 0;
+    }
+
+    .whitewaveblock-img {
+        padding-left: 0;
+    }
+
+    .whitewaveblock-img img{
+        width: 80%;
+        max-width: 250px;
+        min-width: 160px;
+    }
+
+}
+
+@media screen and (max-width: 750px) {
+
+    .whitewaveblock {
+        height: 490px;
+    }
+
+    .whitewaveblock-wave {
+        margin-top: -1em;
+    }
+
+}
+
+@media screen and (max-width: 640px) {
+
+    .whitewaveblock {
+        height: 450px;
+    }
+
+}

--- a/src/assets/WhatWeDo/WhiteWaveBlock.css
+++ b/src/assets/WhatWeDo/WhiteWaveBlock.css
@@ -79,7 +79,6 @@
         padding-left: 10%;
         padding-right: 10%;
         display: flex;
-       don't need `flex-direction: column-reverse` at this width
     }
 
 }
@@ -90,7 +89,6 @@
         padding-left: 8%;
         padding-right: 8%;
         display: flex;
-        don't need `flex-direction: column-reverse` at this width
     }
 
     .whitewaveblock-cta {
@@ -118,7 +116,6 @@
     .whitewaveblock {
         padding-top: 2.5rem;
         display: flex;
-        don't need `flex-direction: column-reverse` at this width
     }
 
 }

--- a/src/assets/WhatWeDo/WhiteWaveBlock.css
+++ b/src/assets/WhatWeDo/WhiteWaveBlock.css
@@ -58,6 +58,7 @@
     .whitewaveblock {
         padding-left: 18%;
         padding-right: 18%;
+        
     }
 
     .whitewaveblock-cta {
@@ -77,6 +78,8 @@
     .whitewaveblock {
         padding-left: 10%;
         padding-right: 10%;
+        display: flex;
+        flex-direction: column-reverse;
     }
 
 }
@@ -86,6 +89,8 @@
     .whitewaveblock {
         padding-left: 8%;
         padding-right: 8%;
+        display: flex;
+        flex-direction: column-reverse;
     }
 
     .whitewaveblock-cta {
@@ -112,6 +117,8 @@
 
     .whitewaveblock {
         padding-top: 2.5rem;
+        display: flex;
+        flex-direction: column-reverse;
     }
 
 }
@@ -126,6 +133,8 @@
         justify-content: center;
         margin-left: 0;
         margin-right: 0;
+        display: flex;
+        flex-direction: column-reverse;
         /*
         position: relative;
         display: flex;
@@ -163,6 +172,8 @@
 
     .whitewaveblock {
         height: 490px;
+        display: flex;
+        flex-direction: column-reverse;
     }
 
     .whitewaveblock-wave {
@@ -175,6 +186,8 @@
 
     .whitewaveblock {
         height: 450px;
+        display: flex;
+        flex-direction: column-reverse;
     }
 
 }

--- a/src/assets/WhatWeDo/WhiteWaveBlock.css
+++ b/src/assets/WhatWeDo/WhiteWaveBlock.css
@@ -161,7 +161,6 @@
 @media screen and (max-width: 750px) {
 
     .whitewaveblock {
-        height: 490px;
         display: flex;
     }
 
@@ -174,7 +173,6 @@
 @media screen and (max-width: 640px) {
 
     .whitewaveblock {
-        height: 450px;
         display: flex;
     }
 

--- a/src/components/WhatWeDo/WhatWeDo.js
+++ b/src/components/WhatWeDo/WhatWeDo.js
@@ -4,8 +4,10 @@ import '../../assets/Projects/Projects.css';
 /*import default_photo from '../../images/light-blue-wave.svg';*/
 import default_photo from '../../images/gray-wave.svg';
 import project_photo from '../../images/project-team-photo.png';
+import whatwedo_photo from '../../images/whiteblock-img.png';
 import tsa_photo from '../../images/tsa-photo.svg';
 import BlueWaveBlock from './BlueWaveBlock';
+import WhiteWaveBlock from './WhiteWaveBlock';
 import TechShift from './Techshift';
 import BlueNewsletterSubBox from './BlueNewsletterSubBox';
 import WhatWeDoBanner from './WhatWeDoBanner';
@@ -20,6 +22,17 @@ export default function WhatWeDo() {
             <BlueWaveBlock
                 imageUrl={project_photo}
                 title="Join our team"
+                text="Lorem ipsum dolor sit amet, consectetur 
+                adipiscing elit. Ultrices ipsum, varius congue enim, 
+                neque. Tincidunt nisl sit quisque nibh consequat 
+                tempor, tortor ultricies."
+                buttonUrl={default_photo}
+                buttonText="Learn more"
+                buttonStyle={"filled"}
+            />
+            <WhiteWaveBlock
+                imageUrl={whatwedo_photo}
+                title="What we do"
                 text="Lorem ipsum dolor sit amet, consectetur 
                 adipiscing elit. Ultrices ipsum, varius congue enim, 
                 neque. Tincidunt nisl sit quisque nibh consequat 

--- a/src/components/WhatWeDo/WhiteWaveBlock.js
+++ b/src/components/WhatWeDo/WhiteWaveBlock.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import '../../assets/WhatWeDo/WhiteWaveBlock.css'
+import CallToAction from "../SharedComponents/CallToAction"
+import Waves from "../SharedComponents/Waves"
+
+const WhiteWaveBlock = ({ imageUrl, title, text, buttonUrl, buttonText, buttonStyle}) => {
+    return (
+        <>
+            <div className="whitewaveblock-container">
+                <div className="whitewaveblock" >
+                    <div className="whitewaveblock-cta">
+                        <CallToAction 
+                            title={title} 
+                            text={text} 
+                            buttonUrl={buttonUrl} 
+                            buttonText={buttonText} 
+                            buttonStyle={buttonStyle}
+                        />
+                    </div>
+                    <div className="break"></div>
+                    <div className="whitewaveblock-img">
+                        <img src={imageUrl} alt=""/>
+                    </div>
+                    
+                </div>
+            </div>
+        </>
+    )
+}
+
+export default WhiteWaveBlock


### PR DESCRIPTION
I added in the additional section in the "whatwedo" page. However, I'm not as familiar with styling and couldn't figure out how the picture and text should reformat correctly when the page becomes thinner. When it is in a wide view it looks correct. 
<img width="1365" alt="Screen Shot 2021-09-04 at 4 19 30 PM" src="https://user-images.githubusercontent.com/21699576/132110221-67938472-cafc-4fa3-b7d2-c4e9e3c7c611.png">

However in the extremely thin view, it doesn't format correctly. I messed around with `flex-direction: column-reverse;`, but couldn't get it to work. 


<img width="980" alt="Screen Shot 2021-09-04 at 4 19 42 PM" src="https://user-images.githubusercontent.com/21699576/132110220-75c5d6cc-40b7-49e0-a6e2-db92c29761ab.png">
